### PR TITLE
feat: add `context` to Chunk

### DIFF
--- a/src/__fixtures__/chunk-context
+++ b/src/__fixtures__/chunk-context
@@ -1,0 +1,7 @@
+diff --git a/rename.js b/rename.js
+index aa39060..0e05564 100644
+--- a/rename.js
++++ b/rename.js
+@@ -4 +4,5 @@ function hello() {
+   // hello world
++  console.log("hello world");

--- a/src/__tests__/__snapshots__/all.test.ts.snap
+++ b/src/__tests__/__snapshots__/all.test.ts.snap
@@ -19,6 +19,7 @@ exports[`aa parse \`all\` 1`] = `
               "type": "DeletedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 2,
             "start": 1,
@@ -43,6 +44,7 @@ exports[`aa parse \`all\` 1`] = `
               "type": "DeletedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 1,
             "start": 1,
@@ -67,6 +69,7 @@ exports[`aa parse \`all\` 1`] = `
               "type": "AddedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 0,
             "start": 0,
@@ -97,6 +100,7 @@ exports[`aa parse \`all\` 1`] = `
               "type": "AddedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 1,
             "start": 1,

--- a/src/__tests__/__snapshots__/chunk-context.test.ts.snap
+++ b/src/__tests__/__snapshots__/chunk-context.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`new-line parse \`new-line\` 1`] = `
+exports[`chunk-context parse \`chunk-context\` 1`] = `
 {
   "files": [
     {
@@ -8,30 +8,30 @@ exports[`new-line parse \`new-line\` 1`] = `
         {
           "changes": [
             {
-              "content": "newfile",
-              "lineAfter": 1,
-              "lineBefore": 1,
+              "content": "  // hello world",
+              "lineAfter": 4,
+              "lineBefore": 4,
               "type": "UnchangedLine",
             },
             {
-              "content": "newline",
-              "lineAfter": 2,
+              "content": "  console.log(\"hello world\");",
+              "lineAfter": 5,
               "type": "AddedLine",
             },
           ],
-          "context": undefined,
+          "context": "function hello() {",
           "fromFileRange": {
-            "lines": 1,
-            "start": 1,
+            "lines": 4,
+            "start": 4,
           },
           "toFileRange": {
-            "lines": 2,
-            "start": 1,
+            "lines": 5,
+            "start": 4,
           },
           "type": "Chunk",
         },
       ],
-      "path": "rename.md",
+      "path": "rename.js",
       "type": "ChangedFile",
     },
   ],

--- a/src/__tests__/__snapshots__/conflict-file.test.ts.snap
+++ b/src/__tests__/__snapshots__/conflict-file.test.ts.snap
@@ -76,6 +76,7 @@ exports[`conflict-file parse \`conflict-file\` 1`] = `
               "type": "UnchangedLine",
             },
           ],
+          "context": undefined,
           "fromFileRangeA": {
             "lines": 7,
             "start": 8,

--- a/src/__tests__/__snapshots__/deleted-file.test.ts.snap
+++ b/src/__tests__/__snapshots__/deleted-file.test.ts.snap
@@ -13,6 +13,7 @@ exports[`deleted-file parse \`deleted-file\` 1`] = `
               "type": "DeletedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 1,
             "start": 1,

--- a/src/__tests__/__snapshots__/deleted-line.test.ts.snap
+++ b/src/__tests__/__snapshots__/deleted-line.test.ts.snap
@@ -19,6 +19,7 @@ exports[`deleted-line parse \`deleted-line\` 1`] = `
               "type": "DeletedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 2,
             "start": 1,

--- a/src/__tests__/__snapshots__/message-line.test.ts.snap
+++ b/src/__tests__/__snapshots__/message-line.test.ts.snap
@@ -28,6 +28,7 @@ exports[`message-line parse \`message-line\` 1`] = `
               "type": "MessageLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 2,
             "start": 1,
@@ -67,6 +68,7 @@ exports[`message-line parse \`message-line\` 1`] = `
               "type": "MessageLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 2,
             "start": 1,

--- a/src/__tests__/__snapshots__/new-file.test.ts.snap
+++ b/src/__tests__/__snapshots__/new-file.test.ts.snap
@@ -13,6 +13,7 @@ exports[`new-file parse \`new-file\` 1`] = `
               "type": "AddedLine",
             },
           ],
+          "context": undefined,
           "fromFileRange": {
             "lines": 0,
             "start": 0,

--- a/src/__tests__/chunk-context.test.ts
+++ b/src/__tests__/chunk-context.test.ts
@@ -1,0 +1,10 @@
+import { getFixture } from './test-utils';
+import parseGitDiff from '../parse-git-diff';
+
+describe('chunk-context', () => {
+  const fixture = getFixture('chunk-context');
+
+  it('parse `chunk-context`', () => {
+    expect(parseGitDiff(fixture)).toMatchSnapshot();
+  });
+});

--- a/src/parse-git-diff.ts
+++ b/src/parse-git-diff.ts
@@ -175,12 +175,13 @@ function parseExtendedHeader(ctx: Context) {
 
 function parseChunkHeader(ctx: Context) {
   const line = ctx.getCurLine();
-  const normalChunkExec = /^@@\s\-(\d+),?(\d+)?\s\+(\d+),?(\d+)?\s@@/.exec(
-    line
-  );
+  const normalChunkExec =
+    /^@@\s\-(\d+),?(\d+)?\s\+(\d+),?(\d+)?\s@@\s?(.+)?/.exec(line);
   if (!normalChunkExec) {
     const combinedChunkExec =
-      /^@@@\s\-(\d+),?(\d+)?\s\-(\d+),?(\d+)?\s\+(\d+),?(\d+)?\s@@@/.exec(line);
+      /^@@@\s\-(\d+),?(\d+)?\s\-(\d+),?(\d+)?\s\+(\d+),?(\d+)?\s@@@\s?(.+)?/.exec(
+        line
+      );
 
     if (!combinedChunkExec) {
       return null;
@@ -194,18 +195,22 @@ function parseChunkHeader(ctx: Context) {
       delLinesB,
       addStart,
       addLines,
+      context,
     ] = combinedChunkExec;
     ctx.nextLine();
     return {
+      context,
       type: 'Combined',
       fromFileRangeA: getRange(delStartA, delLinesA),
       fromFileRangeB: getRange(delStartB, delLinesB),
       toFileRange: getRange(addStart, addLines),
     } as const;
   }
-  const [all, delStart, delLines, addStart, addLines] = normalChunkExec;
+  const [all, delStart, delLines, addStart, addLines, context] =
+    normalChunkExec;
   ctx.nextLine();
   return {
+    context,
     type: 'Normal',
     toFileRange: getRange(addStart, addLines),
     fromFileRange: getRange(delStart, delLines),

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface Chunk extends Base<'Chunk'> {
   fromFileRange: ChunkRange;
   toFileRange: ChunkRange;
   changes: AnyLineChange[];
+  context: string | undefined;
 }
 
 export interface CombinedChunk extends Base<'CombinedChunk'> {
@@ -47,6 +48,7 @@ export interface CombinedChunk extends Base<'CombinedChunk'> {
   fromFileRangeB: ChunkRange;
   toFileRange: ChunkRange;
   changes: AnyLineChange[];
+  context: string | undefined;
 }
 
 export type AnyChunk = Chunk | CombinedChunk;


### PR DESCRIPTION
Adds a `Chunk.context` entry with the context of the Chunk

e.g.
```diff
diff --git a/rename.js b/rename.js
index aa39060..0e05564 100644
--- a/rename.js
+++ b/rename.js
@@ -4 +4,5 @@ function hello() {
   // hello world
+  console.log("hello world");
```

will result in a chunk with
```js
{
	// ...
	context: "function hello() {",
    // ...
}
```